### PR TITLE
Bug- avisos admin

### DIFF
--- a/components/screens/Administrator/AdminBroadcastForm.js
+++ b/components/screens/Administrator/AdminBroadcastForm.js
@@ -58,7 +58,7 @@ function AdminBroadcastForm(props) {
           setError("Ha ocurrido un error");
           setIsLoading(false);
         });
-      Alert.alert("Éxito", "Se ha registrado el alojamiento correctamente.");
+      Alert.alert("Éxito", "Se ha registrado el aviso correctamente.");
       navigation.popToTop();
     }
   };


### PR DESCRIPTION
Se ha corregido un pequeño error en la alerta al crear un aviso de administrador. Ahora al crear el aviso salta una alerta diciendo: "Se ha registrado el aviso correctamente."

Closes #174