### PR TITLE
feat - mejora de request

### DIFF
--- a/components/screens/CreateRequestAccommodation.js
+++ b/components/screens/CreateRequestAccommodation.js
@@ -45,6 +45,10 @@ function createRequestAccommodation(props) {
   const [newOwner, setNewOwner] = useState([]);
 
   const [newPrice, setNewPrice] = useState(
+    navigation.state.params.formData.price
+  );
+
+  const [newSalary, setNewSalary] = useState(
     navigation.state.params.formData.salary
   );
 
@@ -102,6 +106,7 @@ function createRequestAccommodation(props) {
       pending: newPending,
       owner: newOwner.id,
       price: newPrice,
+      salary: Number(newSalary),
       type: newType,
       isCanceled: newIsCanceled,
       startTime: x.toISOString(),

--- a/components/screens/CreateRequestWalk.js
+++ b/components/screens/CreateRequestWalk.js
@@ -19,6 +19,7 @@ import { searchWalksStyles } from "../styles/searchWalkStyle";
 function createRequest(props) {
   const { navigation } = props;
   const [newPrice, setNewPrice] = useState(navigation.state.params.price);
+  const [salary, setSalary] = useState(navigation.state.params.salary);
 
   const price = navigation.state.params.price;
   const [newInterval, setNewInterval] = useState(null);
@@ -46,6 +47,7 @@ function createRequest(props) {
 
   const [wauwerPrices, setWauwerPrices] = useState([]);
   const value = navigation.state.params.interval;
+
 
   useEffect(() => {
     // To retrieve the walker availabilities
@@ -123,6 +125,7 @@ function createRequest(props) {
       availability: value.id,
       isFinished: newIsFinished,
       isRated: newIsRated,
+      salary: salary,
     };
     db.ref("requests/" + id)
       .set(requestData)

--- a/components/screens/FormRequestAccommodation.js
+++ b/components/screens/FormRequestAccommodation.js
@@ -100,6 +100,7 @@ function FormRequestAccommodation(props) {
       idAccommodation: navigation.state.params.accommodation.id,
       pending: navigation.state.params.accommodation.pending,
       salary: navigation.state.params.accommodation.salary,
+      price: navigation.state.params.accommodation.price,
       worker: navigation.state.params.accommodation.worker,
       isCanceled: navigation.state.params.accommodation.isCanceled,
       startTime: newStartTime,

--- a/components/screens/SearchWalks.js
+++ b/components/screens/SearchWalks.js
@@ -281,12 +281,14 @@ function Wauwer(props) {
   });
 
   let price;
+  let salary;
   db.ref("availabilities-wauwers")
     .child(id)
     .child("availabilities")
     .child(wauwerData.item[1])
     .once("value", (snap) => {
       price = snap.val().price;
+      salary = snap.val().myPrice;
     });
 
   const checkHasPets = () => {
@@ -294,6 +296,7 @@ function Wauwer(props) {
       navigation.navigate("CreateRequestWalk", {
         wauwer: user,
         price: price,
+        salary: salary,
         interval: interval,
       });
     } else {


### PR DESCRIPTION
Se ha añadido el atributo salario a las request de paseo como de alojamiento.
También se ha arreglado un error donde se usaba el salario del wauwer para calcular el precio total del alojamiento, y no se usaba el precio con comisiones.

Closes #206 